### PR TITLE
Update MultiZarrToZarr args

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -254,22 +254,8 @@
     "    json_list,\n",
     "    remote_protocol=\"s3\",\n",
     "    remote_options={'anon':True},\n",
-    "    xarray_open_kwargs={\n",
-    "        \"decode_cf\" : False,\n",
-    "        \"mask_and_scale\" : False,\n",
-    "        \"decode_times\" : False,\n",
-    "        \"decode_timedelta\" : False,\n",
-    "        \"use_cftime\" : False,\n",
-    "        \"decode_coords\" : False\n",
-    "    },\n",
-    "    xarray_concat_args={\n",
-    "        'data_vars' : 'minimal',\n",
-    "        'coords' : 'minimal',\n",
-    "        'compat' : 'override',\n",
-    "        'join' : 'override', \n",
-    "        'combine_attrs' : 'override',\n",
-    "        'dim' : 't'\n",
-    "    }\n",
+    "    concat_dims='t',\n",
+    "    inline_threshold=0\n",
     ")"
    ]
   },
@@ -397,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`kerchunk.combine.MultiZarrToZarr()` changed from Kerchunk 0.0.5 -> 0.0.6. This PR updates the tutorial to use the new arguments and fixes errors like #4.

`inline_treshold=0` also had to be specified to keep things running quickly. This is a known problem https://github.com/fsspec/kerchunk/issues/145